### PR TITLE
ntfs: fix deadlock in ntfs_may_write_mft_block

### DIFF
--- a/mft.h
+++ b/mft.h
@@ -88,7 +88,7 @@ static inline int write_mft_record(struct ntfs_inode *ni, struct mft_record *m, 
 
 bool ntfs_may_write_mft_record(struct ntfs_volume *vol,
 		const unsigned long mft_no, const struct mft_record *m,
-		struct ntfs_inode **locked_ni);
+		struct ntfs_inode **locked_ni, struct inode **ref_vi);
 int ntfs_mft_record_alloc(struct ntfs_volume *vol, const int mode,
 		struct ntfs_inode **ni, struct ntfs_inode *base_ni,
 		struct mft_record **ni_mrec);


### PR DESCRIPTION
A deadlock could happen in the way:

  foli_lock                             --- (1)
  ntfs_write_mft_block
    ntfs_may_write_mft_record
      iput
        ntfs_evict_big_inode
          ntfs_mft_record_free
            folio_lock                  --- (1)

Ths patch prevents inodes from being
evicted while a folio is locked.