### PR TITLE
ntfs: fix build error on v7.0.0

### DIFF
--- a/aops.c
+++ b/aops.c
@@ -39,7 +39,7 @@ static void ntfs_iomap_read_end_io(struct bio *bio)
 }
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
 static void ntfs_iomap_bio_submit_read(const struct iomap_iter *iter,
 	struct iomap_read_folio_ctx *ctx)
 {

--- a/mft.c
+++ b/mft.c
@@ -814,7 +814,7 @@ err_out:
 	return err;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
 static int ntfs_test_inode_wb(struct inode *vi, u64 ino, void *data)
 #else
 static int ntfs_test_inode_wb(struct inode *vi, unsigned long ino, void *data)


### PR DESCRIPTION
```
make[1]: Entering directory '/usr/lib/modules/7.0.0-1-tachyon/build'
make[2]: Entering directory '/var/lib/dkms/ntfs/2026.04.14+94d524a/build'
  CC [M]  aops.o
aops.c:53:35: error: ‘iomap_bio_read_folio_range’ undeclared here (not in a function); did you mean ‘iomap_bio_read_folio’?
   53 |         .read_folio_range       = iomap_bio_read_folio_range,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                   iomap_bio_read_folio
aops.c:54:35: error: initialization of ‘void (*)(struct iomap_read_folio_ctx *)’ from incompatible pointer type ‘void (*)(const struct iomap_iter *, struct iomap_read_folio_ctx *)’ [-Wincompatible-pointer-types]
   54 |         .submit_read            = ntfs_iomap_bio_submit_read,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
aops.c:54:35: note: (near initialization for ‘ntfs_iomap_bio_read_ops.submit_read’)
aops.c:43:13: note: ‘ntfs_iomap_bio_submit_read’ declared here
   43 | static void ntfs_iomap_bio_submit_read(const struct iomap_iter *iter,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
make[4]: *** [/usr/lib/modules/7.0.0-1-tachyon/build/scripts/Makefile.build:289: aops.o] Error 1
make[3]: *** [/usr/lib/modules/7.0.0-1-tachyon/build/Makefile:2105: .] Error 2
make[2]: *** [/usr/lib/modules/7.0.0-1-tachyon/build/Makefile:248: __sub-make] Error 2
make[2]: Leaving directory '/var/lib/dkms/ntfs/2026.04.14+94d524a/build'
make[1]: *** [Makefile:248: __sub-make] Error 2
make[1]: Leaving directory '/usr/lib/modules/7.0.0-1-tachyon/build'
make: *** [Makefile:22: all] Error 2

```