### PR TITLE
ntfs: conditionally enable POSIX ACL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ntfs-y := aops.o attrib.o collate.o dir.o file.o index.o inode.o \
 	  iomap.o debug.o sysctl.o quota.o object_id.o bdev-io.o
 
 ccflags-$(CONFIG_NTFS_DEBUG) += -DDEBUG
-ccflags-y += -DCONFIG_NTFS_FS_POSIX_ACL
+ccflags-$(CONFIG_FS_POSIX_ACL) += -DCONFIG_NTFS_FS_POSIX_ACL=1
 else
 # Called from external kernel module build
 


### PR DESCRIPTION
Only enable POSIX ACL if the kernel has built-in support. Fix build on kernels without POSIX ACL.

Closes: #49