### PR TITLE
fix: add bounds check before memcpy in ea.c

### DIFF
--- a/ea.c
+++ b/ea.c
@@ -301,6 +301,10 @@ alloc_new_ea:
 	 * problems with earlier versions.
 	 */
 	p_ea = (struct ea_attr *)ea_buf;
+	if (offsetof(struct ea_attr, ea_name) + name_len + 1 + val_size > new_ea_size) {
+		err = -EINVAL;
+		goto out;
+	}
 	memcpy(p_ea->ea_name, name, name_len);
 	p_ea->ea_name_length = name_len;
 	p_ea->ea_name[name_len] = 0;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `ea.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `ea.c:304` |

**Description**: In ea.c at lines 304 and 307, two memcpy calls copy EA (Extended Attribute) name and value data into a heap-allocated kernel buffer without validating that name_len and val_size fit within the allocated buffer size. The allocation size is computed from on-disk fields that an attacker controls. If those fields are crafted to be inconsistent — for example, the allocation size is smaller than name_len + val_size + overhead — the memcpy writes beyond the heap allocation boundary, corrupting adjacent kernel heap metadata and data structures.

## Changes
- `ea.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
