### PR TITLE
ntfs: avoid self-deadlock during inode eviction

### DIFF
--- a/aops.c
+++ b/aops.c
@@ -486,6 +486,8 @@ static int ntfs_writepages(struct address_space *mapping,
 #else
 	struct iomap_writepage_ctx wpc = { };
 #endif
+	bool need_iput = false;
+	int ret;
 
 	if (NVolShutdown(ni->vol))
 		return -EIO;
@@ -502,11 +504,24 @@ static int ntfs_writepages(struct address_space *mapping,
 		return -EOPNOTSUPP;
 	}
 
+	/*
+	 * Prevent eviction in writeback to avoid deadlock in
+	 * ntfs_drop_big_inode().
+	 */
+	if ((ni->type == AT_DATA || ni->type == AT_INDEX_ALLOCATION) &&
+	    igrab(inode))
+		need_iput = true;
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
-	return iomap_writepages(&wpc);
+	ret = iomap_writepages(&wpc);
 #else
-	return iomap_writepages(mapping, wbc, &wpc, &ntfs_writeback_ops);
+	ret = iomap_writepages(mapping, wbc, &wpc, &ntfs_writeback_ops);
 #endif
+
+	if (need_iput)
+		iput(inode);
+
+	return ret;
 }
 
 static int ntfs_swap_activate(struct swap_info_struct *sis,


### PR DESCRIPTION
An attribute-list update performed while allocating clusters can drop the last reference to the temporary attribute inode. Evicting that inode drops its reference to the base inode and can invoke ntfs_drop_big_inode() for the base inode from within the base inode's own writeback path.

If the base inode is unlinked, ntfs_drop_big_inode() calls truncate_setsize(), which waits for the inode's folio writeback to complete. The same writeback worker is responsible for completing that writeback, so it waits for itself indefinitely.

Prevent this self-deadlock by grabbing a reference to the base inode at the beginning of ntfs_writepages() and releasing it at the end of the function. This defers eviction until all bios have been submitted, allowing the wait for folio writeback to complete safely.