### PR TITLE
Add support for filenames with a colon

### DIFF
--- a/namei.c
+++ b/namei.c
@@ -49,7 +49,7 @@ static inline int ntfs_check_bad_char(const __le16 *wc, unsigned int wc_len)
 
 		if (c < 0x0020 ||
 		    c == 0x0022 || c == 0x002A || c == 0x002F ||
-		    c == 0x003A || c == 0x003C || c == 0x003E ||
+		    c == 0x003C || c == 0x003E ||
 		    c == 0x003F || c == 0x005C || c == 0x007C)
 			return -EINVAL;
 	}


### PR DESCRIPTION
Previously, this driver lacked support for filenames with a colon (`:`), meaning some applications like Wine and Proton simply didn't work.

But filenames with a colon works in ntfs3 (I think in ntfs-3g as well). Regardless, even though Windows doesn't support it, this is Linux, and the requirements are different. AFAIK, Windows chkdsk won't mark filenames with `:` as something that needs to be fixed.